### PR TITLE
Fix: This fixes a bug where Delete Prompt logic is inverse 

### DIFF
--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -369,7 +369,7 @@ def _main():
     print()
 
     if should_delete_images:
-        should_delete_images = input('Do you really want to delete the assets? (y/n): ') != 'y'
+        should_delete_images = input('Do you really want to delete the assets? (y/n): ') == 'y'
     elif backup_assets:
         input('Images will not be deleted but will perform backup. Press any key to continue: ')
     else:


### PR DESCRIPTION
- Currently if the user is asked "Do you really want to delete the assets? (y/n): " and they answer "n", it will delete the files. Answering "y" will not. 
- The logic should be inverse so when the user inputs y, it deletes the assets