### PR TITLE
add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,52 +27,51 @@ Features:
 
 ## Usage
 
+<!--
+  To update the code block with the usage below:
+  
+  1. Resize your terminal to 100 columns. On most systems just run: `stty cols 100 rows 50`.
+  2. Run `storyblok-assets-cleanup --help` to get the usage output.
+-->
+
 ```
-usage: storyblok-assets-cleanup [-h] [--delete | --no-delete] [--backup | --no-backup]
-                                [--cache | --no-cache]
+usage: storyblok-assets-cleanup [-h] [--token TOKEN] --space-id SPACE_ID
+                                [--region {eu,us,ca,au,cn}] [--delete | --no-delete]
+                                [--backup | --no-backup] [--backup-directory BACKUP_DIRECTORY]
+                                [--cache | --no-cache] [--cache-directory CACHE_DIRECTORY]
                                 [--continue-download-on-failure | --no-continue-download-on-failure]
-                                [--space-id SPACE_ID] [--token TOKEN]
                                 [--blacklisted-folder-paths BLACKLISTED_FOLDER_PATHS]
                                 [--blacklisted-words BLACKLISTED_WORDS]
-                                [--cache-directory CACHE_DIRECTORY]
-                                [--backup-directory BACKUP_DIRECTORY]
 
 storyblok-assets-cleanup an utility to delete unused assets.
 
 options:
   -h, --help            show this help message and exit
-
-  --delete, --no-delete
-                        If we should delete assets, default to false.
-
-  --backup, --no-backup
-                        If we should backup assets (to ./assets_backup/<SPACE_ID>), defaults to
-                        true.
-
-  --cache, --no-cache   If we should use cache the assets index. Defaults to True (recommended).
-
-  --continue-download-on-failure, --no-continue-download-on-failure
-                        If we should continue if the download of an asset fails. Defaults to true.
-
-  --space-id SPACE_ID   Storyblok space ID, alternatively use the env var STORYBLOK_SPACE_ID.
-
   --token TOKEN         Storyblok personal access token, alternatively use the env var
                         STORYBLOK_PERSONAL_ACCESS_TOKEN.
-
-  --blacklisted-folder-paths BLACKLISTED_FOLDER_PATHS
-                        Comma separated list of filepaths that should be ignored. Alternatively use
-                        the env var BLACKLISTED_ASSET_FOLDER_PATHS. Default to none/empty list.
-
-  --blacklisted-words BLACKLISTED_WORDS
-                        Comma separated list of words that should be used to ignore assets when they
-                        are contained in its filename. Alternatively use the env var
-                        BLACKLISTED_ASSET_FILENAME_WORDS. Default to none/empty list.
-
-  --cache-directory CACHE_DIRECTORY
-                        Cache directory, defaults to ./cache.
-
+  --space-id SPACE_ID   Storyblok space ID, alternatively use the env var STORYBLOK_SPACE_ID.
+  --region {eu,us,ca,au,cn}
+                        Storyblok region (default: EU)
+  --delete, --no-delete
+                        If we should delete assets, default to false.
+  --backup, --no-backup
+                        If we should backup assets (to the directory specified in `--backup-
+                        directory`), defaults to true.
   --backup-directory BACKUP_DIRECTORY
                         Backup directory, defaults to ./assets_backup.
+  --cache, --no-cache   If we should use cache the assets index. Defaults to True (recommended).
+  --cache-directory CACHE_DIRECTORY
+                        Cache directory, defaults to ./cache.
+  --continue-download-on-failure, --no-continue-download-on-failure
+                        If we should continue if the download of an asset fails. Defaults to true.
+  --blacklisted-folder-paths BLACKLISTED_FOLDER_PATHS
+                        Comma separated list of filepaths that should be ignored. Alternatively
+                        use the env var BLACKLISTED_ASSET_FOLDER_PATHS. Default to none/empty
+                        list.
+  --blacklisted-words BLACKLISTED_WORDS
+                        Comma separated list of words that should be used to ignore assets when
+                        they are contained in its filename. Alternatively use the env var
+                        BLACKLISTED_ASSET_FILENAME_WORDS. Default to none/empty list.
 ```
 
 ## Development

--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -161,6 +161,32 @@ def _main():
     )
 
     parser.add_argument(
+        '--token',
+        type=str,
+        default=getenv('STORYBLOK_PERSONAL_ACCESS_TOKEN'),
+        required=getenv('STORYBLOK_PERSONAL_ACCESS_TOKEN') is None,
+        help=(
+            'Storyblok personal access token, '
+            'alternatively use the env var STORYBLOK_PERSONAL_ACCESS_TOKEN.'
+        ),
+    )
+    parser.add_argument(
+        '--space-id',
+        type=str,
+        default=getenv('STORYBLOK_SPACE_ID'),
+        required=getenv('STORYBLOK_SPACE_ID') is None,
+        help=(
+            'Storyblok space ID, alternatively use the env var STORYBLOK_SPACE_ID.'
+        ),
+    )
+    parser.add_argument(
+        '--region',
+        type=str,
+        default=StoryblokClient.DEFAULT_REGION,
+        choices=list(StoryblokClient.REGION_TO_BASE_URLS.keys()),
+        help='Storyblok region (default: EU)'
+    )
+    parser.add_argument(
         '--delete',
         action=argparse.BooleanOptionalAction,
         type=bool,
@@ -172,7 +198,16 @@ def _main():
         action=argparse.BooleanOptionalAction,
         type=bool,
         default=True,
-        help='If we should backup assets (to ./assets_backup/<SPACE_ID>), defaults to true.',
+        help=(
+            'If we should backup assets (to the directory specified in `--backup-directory`), '
+            'defaults to true.'
+        ),
+    )
+    parser.add_argument(
+        '--backup-directory',
+        type=str,
+        default='assets_backup',
+        help='Backup directory, defaults to ./assets_backup.',
     )
     parser.add_argument(
         '--cache',
@@ -184,38 +219,17 @@ def _main():
         ),
     )
     parser.add_argument(
+        '--cache-directory',
+        type=str,
+        default='cache',
+        help='Cache directory, defaults to ./cache.',
+    )
+    parser.add_argument(
         '--continue-download-on-failure',
         action=argparse.BooleanOptionalAction,
         type=bool,
         default=True,
         help='If we should continue if the download of an asset fails. Defaults to true.',
-    )
-
-    parser.add_argument(
-        '--space-id',
-        type=str,
-        default=getenv('STORYBLOK_SPACE_ID'),
-        required=getenv('STORYBLOK_SPACE_ID') is None,
-        help=(
-            'Storyblok space ID, alternatively use the env var STORYBLOK_SPACE_ID.'
-        ),
-    )
-    parser.add_argument(
-        '--token',
-        type=str,
-        default=getenv('STORYBLOK_PERSONAL_ACCESS_TOKEN'),
-        required=getenv('STORYBLOK_PERSONAL_ACCESS_TOKEN') is None,
-        help=(
-            'Storyblok personal access token, '
-            'alternatively use the env var STORYBLOK_PERSONAL_ACCESS_TOKEN.'
-        ),
-    )
-    parser.add_argument(
-        '--region',
-        type=str,
-        default=StoryblokClient.DEFAULT_REGION,
-        choices=list(StoryblokClient.REGION_TO_BASE_URLS.keys()),
-        help='Storyblok region (default: EU)'
     )
     parser.add_argument(
         '--blacklisted-folder-paths',
@@ -237,18 +251,6 @@ def _main():
             'Alternatively use the env var BLACKLISTED_ASSET_FILENAME_WORDS. '
             'Default to none/empty list.'
         ),
-    )
-    parser.add_argument(
-        '--cache-directory',
-        type=str,
-        default='cache',
-        help='Cache directory, defaults to ./cache.',
-    )
-    parser.add_argument(
-        '--backup-directory',
-        type=str,
-        default='assets_backup',
-        help='Backup directory, defaults to ./assets_backup.',
     )
 
     args = parser.parse_args()

--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -12,7 +12,8 @@ import requests
 class StoryblokClient:
     """
     Class that handles the storyblok client credentials as a global state.
-    Useful in this script context but careful to not re-use (or import) this where the global state matters.
+    Useful in this script context but careful to not re-use (or import)
+     this where the global state might affect your application.
     """
 
     _storyblok_space_id: str
@@ -31,6 +32,13 @@ class StoryblokClient:
 
     @classmethod
     def init_client(cls, space_id, token, region):
+        if (
+            cls._storyblok_space_id
+            or cls._storyblok_personal_access_token
+            or cls._storyblok_base_url
+        ):
+            raise RuntimeError("StoryblokClient already initialized")
+
         cls.storyblok_space_id = space_id
         cls.storyblok_personal_access_token = token
         cls.storyblok_base_url = cls.REGION_TO_BASE_URLS[region]

--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -133,7 +133,6 @@ def get_all_paginated(path, item_name, params={}):
 
 def is_asset_in_use(asset):
     file_path = asset['filename'].split('.storyblok.com', 1)[1]
-    print(file_path)
     response = request(
         'GET',
         '/stories',
@@ -148,7 +147,6 @@ def is_asset_in_use(asset):
     response.raise_for_status()
 
     stories = response.json()['stories']
-    print(stories)
     return len(stories) != 0
 
 


### PR DESCRIPTION
This PR adds support for different regions to the Storyblok asset cleanup script. Previously, the script only worked with the EU region, but with this change, it can now be used with any region supported by Storyblok.
The script now accepts a --region flag, which allows users to specify the region they want to use. The region is used to determine the base URL for the Storyblok API, which is necessary for the script to work correctly.
Additionally, the script now uses a more flexible way of extracting the file path from the asset URL, which should work correctly regardless of the region or URL prefix.
Changes:
Add --region flag to allow users to specify the region
Update init_storyblok_client function to use the specified region
Update request function to use the correct base URL for the region
Update is_asset_in_use function to correctly extract file path from asset URL for storyblok asset URLS even if they aren't EU based. 
