### PR TITLE
fix: respect ignore filters in asset deletion loop

### DIFF
--- a/storyblok_assets_cleanup.py
+++ b/storyblok_assets_cleanup.py
@@ -511,7 +511,9 @@ def _main():  # noqa: C901, PLR0915
         input("Dry run mode: nothing will be done. Press any key to continue: ")
 
     for asset in assets_not_in_use:
-        asset_path_name = folder_id_to_path_name[asset["asset_folder_id"]]
+        if not asset["to_be_deleted"]:
+            print(f"Skipping asset {asset['id']} (matched ignore filter)")
+            continue
 
         if backup_assets:
             if file_path := backup_asset(
@@ -536,7 +538,7 @@ def _main():  # noqa: C901, PLR0915
 
         else:
             print(
-                f"Did not delete te asset {asset['id']!r}. To enable deletion use the --delete flag"
+                f"Did not delete the asset {asset['id']!r}. To enable deletion use the --delete flag"
             )
 
         if backup_assets or should_delete_assets:


### PR DESCRIPTION
Hi! 

Please be aware the below description and PR changes were generated by Claude Code, as I don't really do much Python. 

However we've used your script a few times and had issues with blacklisted/ignored items being deleted that we had to put back manually by hand. The AI detected the below issue/fix, and it seemed to work as expected in a test run (~10k assets, ~50 ignored no issues). Hope it's helpful.

---

:robot:

**Summary**                                                                                                     
                                                                                                              
  - Assets matched by --ignore-path / --ignore-word (formerly --blacklisted-path / --blacklisted-word) were   
  still being backed up and deleted despite the filters
  - The should_be_deleted() function correctly sets to_be_deleted=False on matched assets, and the summary
  table displays correct counts, but the deletion loop never checked this flag
  - Fix: skip assets with to_be_deleted=False in the deletion loop
  - Also fixes typo: "Did not delete te asset" → "Did not delete the asset"

  **Details**

  The bug has existed since the blacklist feature was originally introduced. The summary table would correctly
   show e.g. "5 of 10 to be deleted", but all 10 would still be backed up and deleted.

  **Test plan**

  - Trace through the code: assets_not_in_use (line 455) includes all unused assets regardless of ignore
  filters → should_be_deleted() sets to_be_deleted on each (line 472) → the deletion loop (line 513) now
  checks the flag before proceeding
  - Run with --ignore-path or --ignore-word and verify matched assets are skipped with a log message
  - Verify non-ignored assets are still backed up and deleted as before
  - make lint passes (no new warnings)